### PR TITLE
chore(deps): upgrade clap from 3.2 to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,26 +192,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "4.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "8e67816e006b17427c9b4386915109b494fec2d929c63e3bd3561234cbf1bf1e"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -222,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1141,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.37"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1683,12 +1681,6 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [dependencies]
 bytemuck = { version = "1.12.0", features = ["derive"] }
-clap = { version = "3.2.17", features = ["derive"] }
+clap = { version = "4.0.19", features = ["derive"] }
 futures = "0.3.23"
 notify = "4.0.17"
 wgpu = { version = "0.13.1", features = ['default', 'naga'] }


### PR DESCRIPTION
```pwsh
L:\git\forks\wgsl-playground [zageron/upgrade_clap_3.2-4.0]> mkdir shaders

    Directory: L:\git\forks\wgsl-playground

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----          2022-11-05    10:54                shaders

L:\git\forks\wgsl-playground [zageron/upgrade_clap_3.2-4.0]> cargo run -- -c shaders/firstshader.wgsl
    Finished dev [unoptimized + debuginfo] target(s) in 0.27s
     Running `target\debug\wgsl-playground.exe -c shaders/firstshader.wgsl`

```

![image](https://user-images.githubusercontent.com/1892473/200134289-74f6bf0f-77f5-4764-b3a5-f1f21ecff04f.png)
