### PR TITLE
main: add a window size tuple to uniforms

### DIFF
--- a/examples/uniforms.wgsl
+++ b/examples/uniforms.wgsl
@@ -6,6 +6,8 @@ struct VertexOutput {
 struct Uniforms {
     mouse: vec2<f32>,
     time: f32,
+    _pad: f32,
+    window_size: vec2<f32>,
 };
 
 @group(0) @binding(0)
@@ -13,9 +15,10 @@ var<uniform> uniforms: Uniforms;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    let normalized = (in.coord + vec2<f32>(1., 1.)) / 2.;
+    let aspect = uniforms.window_size.xy * 2.0 / uniforms.window_size.y;
+    let normalized = (in.coord * aspect + vec2<f32>(1., 1.)) / 2.;
     let r = 0.25 + 0.25 * sin(uniforms.time);
-    let delta = abs(uniforms.mouse - in.coord - vec2<f32>(r/2., r/2.)) % vec2<f32>(r, r) - vec2<f32>(r / 2., r / 2.);
+    let delta = abs(uniforms.mouse * aspect - in.coord * aspect - vec2<f32>(r/2., r/2.)) % vec2<f32>(r, r) - vec2<f32>(r / 2., r / 2.);
     let c = dot(delta, delta);
     
     if (c > (r / 100.)) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ struct Uniforms {
     pub mouse: [f32; 2],
     pub time: f32,
     pub pad: f32,
+    pub window_size: [f32; 2],
 }
 
 impl Default for Uniforms {
@@ -57,6 +58,7 @@ impl Default for Uniforms {
             time: 0.,
             mouse: [0.0, 0.0],
             pad: 0.,
+            window_size: [0., 0.],
         }
     }
 }
@@ -194,6 +196,8 @@ impl Playground {
             self.surface_config.height = new_size.height;
 
             self.surface.configure(&self.device, &self.surface_config);
+            let logical_size = new_size.to_logical(self.window.scale_factor());
+            self.uniforms.window_size = [logical_size.width, logical_size.height];
             self.window.request_redraw();
         }
     }


### PR DESCRIPTION
The window size tuple is added after the pad to avoid breaking existing shaders, but that leaves pad in the middle. Perhaps there's a good thing to use pad for.

The uniforms example is updated to utilize the window size to compute an aspect ratio and correct for it.